### PR TITLE
Fix delete undo to restore single object

### DIFF
--- a/docs/regressions/delete-undo.md
+++ b/docs/regressions/delete-undo.md
@@ -1,0 +1,15 @@
+# Delete → Undo Regression Check
+
+This manual regression check ensures removing an object and undoing the action restores the scene to its prior state without duplicating entries.
+
+1. Start the development server with `npm run dev` and open the Clay Studio in the browser.
+2. Create a second clay object ("Add object" button) so that deleting is permitted.
+3. Select the object you plan to remove and note the total object count in the sidebar list.
+4. Delete the selection using the toolbar trash icon or the `Delete` keyboard shortcut.
+   - The object list should shrink by one entry.
+5. Trigger undo (toolbar undo button or `Ctrl/Cmd + Z`).
+   - The deleted object should return exactly once to the list in its original position.
+   - The previously selected object ID should become selected again.
+6. Confirm the object count matches the value from step 3 and no duplicate entries exist.
+
+Document the result in QA notes if any deviation is observed.


### PR DESCRIPTION
## Summary
- update `DeleteObjectCommand` to use a functional state setter so delete and undo work with the latest object collection
- store snapshots to reinstate exactly one deleted object and restore the previous selection on undo
- document a manual regression check covering the delete → undo flow

## Testing
- npm run lint *(fails: pre-existing lint violations in unrelated files)*

------
https://chatgpt.com/codex/tasks/task_b_68d101dc523c8330a27dd8bcdc8c481e

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Improved Delete → Undo behavior to reliably restore the prior scene without duplications.
  * After deleting an object, selection now moves to the first remaining object (or clears if none), ensuring consistent selection state.
  * Undo now fully restores object positions and previous selection where applicable.

* **Documentation**
  * Added a manual regression test guide for Delete → Undo, including setup, action steps, and verification criteria for QA.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->